### PR TITLE
Remove compile dependency on JUnit

### DIFF
--- a/spring-boot-dependencies/pom.xml
+++ b/spring-boot-dependencies/pom.xml
@@ -648,6 +648,13 @@
 				<groupId>com.googlecode.json-simple</groupId>
 				<artifactId>json-simple</artifactId>
 				<version>${simple-json.version}</version>
+				<exclusions>
+					<!-- Remove compile time dependency on junit, see https://github.com/fangyidong/json-simple/issues/91 -->
+					<exclusion>
+						<groupId>junit</groupId>
+						<artifactId>junit</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.h2database</groupId>


### PR DESCRIPTION
With this exclusion, spring-boot users no longer need to exclude the junit dependency in each of their projects.